### PR TITLE
[Fix] 製作ステータスの更新処理、管理者ログイン時のヘッダーに並ぶボタンの遷移先の修正

### DIFF
--- a/app/controllers/admin/order_details_controller.rb
+++ b/app/controllers/admin/order_details_controller.rb
@@ -1,10 +1,10 @@
 class Admin::OrderDetailsController < ApplicationController
 
   def update
-    p @order_detail = OrderDetail.find(params[:id])
+    @order_detail = OrderDetail.find(params[:id])
     @order_detail.production_status = OrderDetail.production_status_methods[params[:order_detail][:production_status_method]]
     @order_detail.update(order_detail_params)
-    redirect_to admin_order_path(@order_detail)
+    redirect_to admin_order_path(@order_detail.order)
   end
 
   private

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
             <!--「root_path」となっている箇所は、適宜修正すること-->
             <%= link_to '商品一覧',admin_items_path,class: 'btn btn-dark mx-3 mt-2' %>
             <%= link_to '会員一覧',admin_customers_path,class: 'btn btn-dark mx-3 mt-2' %>
-            <%= link_to '注文履歴一覧',orders_path,class: 'btn btn-dark mx-3 mt-2' %>
+            <%= link_to '注文履歴一覧',admin_orders_path,class: 'btn btn-dark mx-3 mt-2' %>
             <%= link_to 'ジャンル一覧',admin_genres_path,class: 'btn btn-dark mx-3 mt-2' %>
             <%= link_to 'ログアウト',destroy_admin_session_path, method: :delete, class: 'btn btn-dark mx-3 mt-2' %>
           <% elsif customer_signed_in? %>


### PR DESCRIPTION
下記2点について、修正しました。
① 管理者側の注文詳細画面で製作ステータスの更新処理
② 管理者ログイン後に表示されるのヘッダーに表示されているボタンの遷移先の修正